### PR TITLE
Stricter Updates and Deletes

### DIFF
--- a/caracal.js
+++ b/caracal.js
@@ -60,8 +60,12 @@ app.use('/data/Slide/find', auth.filterHandler('data', 'userFilter', 'filter'));
 app.use('/data/Slide/post', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Slide/post', dataHandlers.Slide.add);
 app.use('/data/Slide/delete', permissionHandler(['Admin', 'Editor']));
+app.use('/data/Slide/delete', dataHandlers.Slide.find);
+app.use('/data/Slide/delete', auth.editHandler('data', 'userFilter', 'filter'));
 app.use('/data/Slide/delete', dataHandlers.Slide.delete);
 app.use('/data/Slide/update', permissionHandler(['Admin', 'Editor']));
+app.use('/data/Slide/update', dataHandlers.Slide.find);
+app.use('/data/Slide/update', auth.editHandler('data', 'userFilter', 'filter'));
 app.use('/data/Slide/update', dataHandlers.Slide.update);
 // mark
 app.use('/data/Mark/find', dataHandlers.Mark.find);

--- a/caracal.js
+++ b/caracal.js
@@ -74,8 +74,12 @@ app.use('/data/Mark/multi', dataHandlers.Mark.multi);
 app.use('/data/Mark/types', dataHandlers.Mark.types);
 app.use('/data/Mark/post', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Mark/post', dataHandlers.Mark.add);
+app.use('/data/Mark/delete', dataHandlers.Mark.find);
+app.use('/data/Mark/delete', auth.editHandler('data'));
 app.use('/data/Mark/delete', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Mark/delete', dataHandlers.Mark.delete);
+app.use('/data/Mark/update', dataHandlers.Mark.find);
+app.use('/data/Mark/update', auth.editHandler('data'));
 app.use('/data/Mark/update', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Mark/update', dataHandlers.Mark.update);
 // template
@@ -91,16 +95,24 @@ app.use('/data/Heatmap/find', dataHandlers.Heatmap.find);
 app.use('/data/Heatmap/types', dataHandlers.Heatmap.types);
 app.use('/data/Heatmap/post', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Heatmap/post', dataHandlers.Heatmap.add);
+app.use('/data/Heatmap/delete', dataHandlers.Heatmap.find);
+app.use('/data/Heatmap/delete', auth.editHandler('data'));
 app.use('/data/Heatmap/delete', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Heatmap/delete', dataHandlers.Heatmap.delete);
+app.use('/data/Heatmap/update', dataHandlers.Heatmap.find);
+app.use('/data/Heatmap/update', auth.editHandler('data'));
 app.use('/data/Heatmap/update', permissionHandler(['Admin', 'Editor']));
 app.use('/data/Heatmap/update', dataHandlers.Heatmap.update);
 // heatmapEdit
 app.use('/data/HeatmapEdit/find', dataHandlers.HeatmapEdit.find);
 app.use('/data/HeatmapEdit/post', permissionHandler(['Admin', 'Editor']));
 app.use('/data/HeatmapEdit/post', dataHandlers.HeatmapEdit.add);
+app.use('/data/HeatmapEdit/delete', dataHandlers.HeatmapEdit.find);
+app.use('/data/HeatmapEdit/delete', auth.editHandler('data'));
 app.use('/data/HeatmapEdit/delete', permissionHandler(['Admin', 'Editor']));
 app.use('/data/HeatmapEdit/delete', dataHandlers.HeatmapEdit.delete);
+app.use('/data/HeatmapEdit/update', dataHandlers.HeatmapEdit.find);
+app.use('/data/HeatmapEdit/update', auth.editHandler('data'));
 app.use('/data/HeatmapEdit/update', permissionHandler(['Admin', 'Editor']));
 app.use('/data/HeatmapEdit/update', dataHandlers.HeatmapEdit.update);
 // log

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -210,7 +210,12 @@ function editHandler(dataField, filterField, attrField) {
     }
     // edit routes should operate on one object
     if (req[dataField].length == 1) {
-      delete req.query;
+      // DESTROY query
+      for (let n in req.query){
+        if (req.query.hasOwnProperty(n)){
+          delete req.query[n]
+        }
+      }
       req.query = {_id: req[dataField][0]._id['$oid']};
     }
     // don't error if 1 or 0 objects

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -217,9 +217,8 @@ function editHandler(dataField, filterField, attrField) {
         }
       }
       req.query = {_id: req[dataField][0]._id['$oid']};
-      next()
-    }
-    else if (req[dataField].length == 0) {
+      next();
+    } else if (req[dataField].length == 0) {
       let errorMessage = {};
       errorMessage.error = 'Nothing applicable to change.';
       errorMessage.statusCode = 400;

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -211,16 +211,19 @@ function editHandler(dataField, filterField, attrField) {
     // edit routes should operate on one object
     if (req[dataField].length == 1) {
       // DESTROY query
-      for (let n in req.query){
-        if (req.query.hasOwnProperty(n)){
-          delete req.query[n]
+      for (let n in req.query) {
+        if (req.query.hasOwnProperty(n)) {
+          delete req.query[n];
         }
       }
       req.query = {_id: req[dataField][0]._id['$oid']};
     }
     // don't error if 1 or 0 objects
     if (req[dataField].length <= 1) {
-      next();
+      let errorMessage = {};
+      errorMessage.error = 'Nothing applicable to change.';
+      errorMessage.statusCode = 200;
+      next(errorMessage);
     } else {
       let errorMessage = {};
       errorMessage.error = 'At most one document may be changed at once.';

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -210,7 +210,7 @@ function editHandler(dataField, filterField, attrField) {
     }
     // edit routes should operate on one object
     if (req[dataField].length == 1) {
-      req.query = {_id: req[dataField][0]._id};
+      req.query = {_id: req[dataField][0]._id['$oid']};
     }
     // don't error if 1 or 0 objects
     if (req[dataField].length <= 1) {

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -217,12 +217,12 @@ function editHandler(dataField, filterField, attrField) {
         }
       }
       req.query = {_id: req[dataField][0]._id['$oid']};
+      next()
     }
-    // don't error if 1 or 0 objects
-    if (req[dataField].length <= 1) {
+    else if (req[dataField].length == 0) {
       let errorMessage = {};
       errorMessage.error = 'Nothing applicable to change.';
-      errorMessage.statusCode = 200;
+      errorMessage.statusCode = 400;
       next(errorMessage);
     } else {
       let errorMessage = {};

--- a/handlers/authHandlers.js
+++ b/handlers/authHandlers.js
@@ -210,6 +210,7 @@ function editHandler(dataField, filterField, attrField) {
     }
     // edit routes should operate on one object
     if (req[dataField].length == 1) {
+      delete req.query;
       req.query = {_id: req[dataField][0]._id['$oid']};
     }
     // don't error if 1 or 0 objects

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -142,7 +142,6 @@ function mongoUpdate(collection, query, newVals) {
   });
 }
 
-
 var Slide = {};
 Slide.find = function(req, res, next) {
   // slide, specimen, study, location

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -103,7 +103,7 @@ function mongoDelete(collection, query) {
             if (err) {
               rej(err);
             }
-            delete result.connection
+            delete result.connection;
             res(result);
             db.close();
           });
@@ -131,7 +131,7 @@ function mongoUpdate(collection, query, newVals) {
             if (err) {
               rej(err);
             }
-            delete result.connection
+            delete result.connection;
             res(result);
             db.close();
           });

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -103,6 +103,7 @@ function mongoDelete(collection, query) {
             if (err) {
               rej(err);
             }
+            delete result.connection
             res(result);
             db.close();
           });
@@ -130,6 +131,7 @@ function mongoUpdate(collection, query, newVals) {
             if (err) {
               rej(err);
             }
+            delete result.connection
             res(result);
             db.close();
           });

--- a/handlers/filterFunction.js
+++ b/handlers/filterFunction.js
@@ -1,0 +1,23 @@
+function filterFunction(filter, data, attr, wildcard) {
+  // make filter an array
+  if (!Array.isArray(filter)) {
+    filter = [filter];
+  }
+  if (filter.indexOf(wildcard) == -1) {
+    // is data an array?
+    if (Array.isArray(data)) {
+      // remove ones where does not match
+      data = data.filter((x) => (!x[attr] || filter.indexOf(x[attr]) >= 0) );
+    } else {
+      if (!data[attr] || filter.indexOf(data[attr]) >= 0) {
+        data = data;
+      } else {
+        data = {};
+      }
+    }
+  }
+  return data;
+}
+
+
+module.exports = filterFunction;

--- a/test/functional/slide_lifecycle.js
+++ b/test/functional/slide_lifecycle.js
@@ -49,7 +49,7 @@ describe('Slide Lifecycle Step 3', function() {
   it('Deletes a Slide', function(done) {
     this.timeout(5000);
     chai.request(server)
-        .delete(deleteurl + "?name=TEST")
+        .delete(deleteurl + '?name=TEST')
         .set('Content-Type', 'application/json; charset=utf-8')
         .end(function(err, res) {
           (res).should.have.status(200);

--- a/test/functional/slide_lifecycle.js
+++ b/test/functional/slide_lifecycle.js
@@ -48,11 +48,9 @@ describe('Slide Lifecycle Step 2', function() {
 describe('Slide Lifecycle Step 3', function() {
   it('Deletes a Slide', function(done) {
     this.timeout(5000);
-    var slideData = {'name': 'TEST', 'specimen': '', 'study': '', 'location': '/images/sample.svs', 'mpp': 0.499};
     chai.request(server)
-        .post(deleteurl)
+        .delete(deleteurl + "?name=TEST")
         .set('Content-Type', 'application/json; charset=utf-8')
-        .send(slideData)
         .end(function(err, res) {
           (res).should.have.status(200);
           (res.body).should.be.a('object');


### PR DESCRIPTION
fixes #15 and #14 

This is a method to conditionally change the update/delete behavior so that it will both only delete when exactly one item is set for deletion (this takes no action if 2+ items match the query, as opposed to just deleting the first), as well as ignores any items a user cannot see.
There is a corner case, that if there are, for example, 100 slides, and a user has filters such that they can only see one, calling delete with no args will delete that.

This is only set up for routes containing auth.editHandler in their call stack.

Also, deleted the connection info while at it.