### PR TITLE
Dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,5 @@ COPY . /root/src
 WORKDIR /root/src
 RUN npm install
 ARG viewer
-RUN if [ -z ${viewer} ]; then git clone https://github.com/camicroscope/camicroscope.git; else git clone https://github.com/camicroscope/camicroscope.git --branch=$viewer; fi
 EXPOSE 8010
 CMD forever caracal.js

--- a/caracal.js
+++ b/caracal.js
@@ -162,7 +162,7 @@ app.use(function(err, req, res, next) {
 
 var startApp = function(app) {
   return function() {
-    app.listen(PORT, () => console.log('listening on ' + PORT + ' changes done 2'));
+    app.listen(PORT, () => console.log('listening on ' + PORT));
   };
 };
 

--- a/caracal.js
+++ b/caracal.js
@@ -56,6 +56,7 @@ app.use('/loader/', loaderHandler);
 app.use('/data', auth.loginHandler(auth.PUBKEY));
 // slide
 app.get('/data/Slide/find', dataHandlers.Slide.find);
+app.get('/data/Slide/find/mark', dataHandlers.Slide.aggregate);
 app.get('/data/Slide/find', auth.filterHandler('data', 'userFilter', 'filter'));
 app.post('/data/Slide/post', permissionHandler(['Admin', 'Editor']));
 app.post('/data/Slide/post', dataHandlers.Slide.add);
@@ -161,7 +162,7 @@ app.use(function(err, req, res, next) {
 
 var startApp = function(app) {
   return function() {
-    app.listen(PORT, () => console.log('listening on ' + PORT));
+    app.listen(PORT, () => console.log('listening on ' + PORT + ' changes done 2'));
   };
 };
 

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -170,13 +170,21 @@ function mongoAggregate(collection, query) {
             }, 
             {
               $lookup: query 
+            },
+            {              
+              $lookup:{
+                  from: "heatmap", 
+                  localField: "slideId", 
+                  foreignField: "provenance.image.slide",
+                  as: "heatmaps"
+              }
               // {
               //   "from": "mark",
               //   "localField": "slideId",
               //   "foreignField": "provenance.image.slide",
               //   "as": "marks"
               // }
-            }
+            }    
           ]).toArray(function(err, result) {
             if (err) {
               rej(err);

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -232,7 +232,7 @@ Slide.get = function(req, res, next) {
 
 Slide.aggregate = function(req, res, next) {
   var query = req.query;
-  console.log(query);
+  // console.log(query);
   delete query.token;
   mongoAggregate('slide', query).then((x) => {
     req.data = x;


### PR DESCRIPTION
This contains the backend data routes for the dashboard as mentioned in [#95](https://github.com/camicroscope/Distro/issues/95). It is able to return the slides along with its respective heatmaps and marks (annotations) in a single request. It requires mongo 4 to be able to run and thus I recommend it to be on a seperate branch until [#116](https://github.com/camicroscope/Distro/pull/116) is accepted.