### PR TITLE
Allow multiple filters on a slide and update filterFunction accordingly [Feature]

### DIFF
--- a/handlers/filterFunction.js
+++ b/handlers/filterFunction.js
@@ -3,7 +3,6 @@ function filterFunction(filter, data, attr, wildcard) {
     try {
       filter = JSON.parse(filter.replace(/'/g, '"'));
     } catch (err) {
-      console.log(err);
       filter=[filter]; // make an array of the filter
     }
   }

--- a/handlers/filterFunction.js
+++ b/handlers/filterFunction.js
@@ -1,18 +1,48 @@
 function filterFunction(filter, data, attr, wildcard) {
-  // make filter an array
-  if (!Array.isArray(filter)) {
-    filter = [filter];
+  if (typeof filter==="string") {
+    try {
+      filter = JSON.parse(filter.replace(/'/g, '"'));
+    } catch (err) {
+      console.log(err);
+      filter=[filter]; // make an array of the filter
+    }
   }
   if (filter.indexOf(wildcard) == -1) {
     // is data an array?
     if (Array.isArray(data)) {
       // remove ones where does not match
-      data = data.filter((x) => (!x[attr] || filter.indexOf(x[attr]) >= 0) );
+      data = data.filter((x) => {
+        let list;
+        if (!x[attr]) {
+          return true;
+        }
+        try {
+          list=JSON.parse(x[attr].replace(/'/g, '"'));
+          return list.some((e) =>filter.indexOf(e) >= 0);
+        } catch (err) { // when list is not an array, but a string
+          list=x[attr];
+          return filter.indexOf(x[attr]) >= 0;
+        }
+      });
     } else {
-      if (!data[attr] || filter.indexOf(data[attr]) >= 0) {
+      if (!data[attr]) {
         data = data;
       } else {
-        data = {};
+        let list;
+        try {
+          list=JSON.parse(data[attr].replace(/'/g, '"'));
+          if (list.some((e) => filter.indexOf(e) >= 0)) {
+            return data;
+          } else {
+            return {};
+          }
+        } catch (err) { // when list is not an array, but a string
+          if (filter.indexOf(data[attr]) >= 0) {
+            return data;
+          } else {
+            return {};
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
Following changes have been made in filterFunction() :

- If the `filter` field of a user is a JSON array (when user doesn't signup, the filter array is, by default a JSON array) , then firstly, it is tried to parse it to an array, otherwise if it is an array, we take it directly. If it is a string but not in JSON format, then an array of length 1 is created out of it.

- If the `filter` field of a slide is an array, we try to filter  the slides which have at least one filter in common with the user filters, otherwise if it is a single string we search the filter in the user filter.

## Motivation and Context
- Earlier, whenever user created an account using the `signup.html` page, the filters were stored as JSON array, but in the filterFunction it was not parsed to an array, but directly converted to an array of length 1 always.
Like, suppose I created a user with filters `['secret' , 'super-secret']` , it would be saved as `"['secret' , 'super-secret']"` and in filterFunction, this was converted to an array that contains only this single string. (But it should have 2 elements 'secret' and 'super-secret', ideally)

- This also allows multiple filters for a slide, required for #camicroscope/caMicroscope/pull/391 , to fix #camicroscope/caMicroscope/issues/386

## How Has This Been Tested?
- This has been tested along with  #camicroscope/caMicroscope/pull/391 , creating various types of users, with various filters. 

## Types of changes
**What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
