### PR TITLE
Server-side Model Training for Development Workbench

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:12-alpine
-RUN apk add git
+FROM node:14-stretch-slim
+RUN apt-get update  &&  apt-get upgrade -y  &&  apt-get install -y git
 RUN mkdir /root/src
 COPY . /root/src
 WORKDIR /root/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:14-stretch-slim
-RUN apt-get update  &&  apt-get upgrade -y  &&  apt-get install -y git
+RUN apt-get update  &&  apt-get upgrade -y  &&  apt-get install -y git build-essential python3
 RUN mkdir /root/src
 COPY . /root/src
 WORKDIR /root/src

--- a/caracal.js
+++ b/caracal.js
@@ -14,6 +14,8 @@ const proxyHandler = require('./handlers/proxyHandler.js');
 const permissionHandler = require('./handlers/permssionHandler.js');
 const dataHandlers = require('./handlers/dataHandlers.js');
 const sanitizeBody = require('./handlers/sanitizeHandler.js');
+const DataSet = require('./handlers/datasetHandler.js');
+const Model = require('./handlers/modelTrainer.js');
 // TODO validation of data
 
 var WORKERS = process.env.NUM_THREADS || 4;
@@ -23,6 +25,21 @@ var PORT = process.env.PORT || 4010;
 
 const app = express();
 app.use(cookieParser());
+
+app.use(express.json({limit: '100mb'}));
+
+// workbench utilities
+app.post('/workbench/uploadDataset', express.json(), DataSet.getDataset);
+app.post('/workbench/trainModel', express.json(), Model.trainModel);
+app.post('/workbench/deleteUserData', express.json(), DataSet.deleteData);
+app.post('/workbench/modelDownload', express.json(), (req, res) => {
+  let downloadURL = '/workbench/download/' + req.body.userFolder;
+  app.get(downloadURL, (req1, res1) =>
+    res1.download('./dataset/' + req.body.userFolder + '/' + req.body.Params.modelName + '.zip'),
+  );
+  res.json({url: downloadURL});
+});
+
 
 // handle non-json raw body for post
 app.use(function(req, res, next) {

--- a/caracal.js
+++ b/caracal.js
@@ -26,10 +26,9 @@ var PORT = process.env.PORT || 4010;
 const app = express();
 app.use(cookieParser());
 
-app.use(express.json({limit: '100mb'}));
 
 // workbench utilities
-app.post('/workbench/uploadDataset', express.json(), DataSet.getDataset);
+app.post('/workbench/uploadDataset', express.json({limit: '100mb'}), DataSet.getDataset);
 app.post('/workbench/trainModel', express.json(), Model.trainModel);
 app.post('/workbench/deleteUserData', express.json(), DataSet.deleteData);
 app.post('/workbench/modelDownload', express.json(), (req, res) => {

--- a/caracal.js
+++ b/caracal.js
@@ -27,19 +27,6 @@ const app = express();
 app.use(cookieParser());
 
 
-// workbench utilities
-app.post('/workbench/uploadDataset', express.json({limit: '100mb'}), DataSet.getDataset);
-app.post('/workbench/trainModel', express.json(), Model.trainModel);
-app.post('/workbench/deleteUserData', express.json(), DataSet.deleteData);
-app.post('/workbench/modelDownload', express.json(), (req, res) => {
-  let downloadURL = '/workbench/download/' + req.body.userFolder;
-  app.get(downloadURL, (req1, res1) =>
-    res1.download('./dataset/' + req.body.userFolder + '/' + req.body.Params.modelName + '.zip'),
-  );
-  res.json({url: downloadURL});
-});
-
-
 // handle non-json raw body for post
 app.use(function(req, res, next) {
   var data = '';
@@ -75,6 +62,10 @@ var HANDLERS = {
   "permissionHandler": permissionHandler,
   "editHandler": auth.editHandler,
   "proxyHandler": proxyHandler,
+  "getDataset": DataSet.getDataset,
+  "trainModel": Model.trainModel,
+  "deleteDataset": DataSet.deleteData,
+  "sendTrainedModel": Model.sendTrainedModel,
   "iipHandler": function() {
     return iipHandler;
   },

--- a/handlers/datasetHandler.js
+++ b/handlers/datasetHandler.js
@@ -1,0 +1,156 @@
+const tf = require('@tensorflow/tfjs-node');
+
+// enable this and comment previous one for GPU (CUDA) training --
+// proper nvidia drivers needs to be installed on both base machine and container for gpu training
+// const tf = require('@tensorflow/tfjs-node-gpu');
+
+const fs = require('fs');
+const inkjet = require('inkjet');
+const crypto = require("crypto");
+const AdmZip = require('adm-zip');
+const path = require('path');
+
+let LABELS_PATH = '';
+let IMAGES_SPRITE_PATH = '';
+
+let datasetImages = [];
+
+class Data {
+  constructor() {
+    this.IMAGE_SIZE = 0;
+    this.NUM_CLASSES = 0;
+    this.NUM_TRAIN_ELEMENTS = 0;
+    this.NUM_TEST_ELEMENTS = 0;
+    this.IMAGES_SPRITE_PATH = IMAGES_SPRITE_PATH;
+    this.NUM_CHANNELS = 0; // 1 for grayscale; 4 for rgba
+    this.LABELS_PATH = LABELS_PATH;
+    this.shuffledTrainIndex = 0;
+    this.shuffledTestIndex = 0;
+  }
+  async load() {
+    const imgRequest = new Promise((resolve) => {
+      // console.log(this.IMAGES_SPRITE_PATH);
+      inkjet.decode(fs.readFileSync(this.IMAGES_SPRITE_PATH), function(err, decoded) {
+        const pixels = Float32Array.from(decoded.data).map((pixel) => {
+          return pixel / 255;
+        });
+        datasetImages = pixels;
+        resolve();
+      });
+    });
+
+    let labelsRequest = fs.readFileSync(this.LABELS_PATH);
+    const [imgResponse, labelsResponse] = await Promise.all([
+      imgRequest,
+      labelsRequest,
+    ]);
+
+    this.datasetLabels = new Uint8Array(labelsResponse);
+
+    // Create shuffled indices into the train/test set for when we select a
+    // random dataset element for training / validation.
+    this.trainIndices = tf.util.createShuffledIndices(this.NUM_TRAIN_ELEMENTS);
+    this.testIndices = tf.util.createShuffledIndices(this.NUM_TEST_ELEMENTS);
+
+    // Slice the the images and labels into train and test sets.
+    this.trainImages = datasetImages.slice(
+        0,
+        this.IMAGE_SIZE * this.NUM_TRAIN_ELEMENTS * this.NUM_CHANNELS,
+    );
+    this.testImages = datasetImages.slice(
+        this.IMAGE_SIZE * this.NUM_TRAIN_ELEMENTS * this.NUM_CHANNELS,
+    );
+    this.trainLabels = this.datasetLabels.slice(
+        0,
+        this.NUM_CLASSES * this.NUM_TRAIN_ELEMENTS,
+    );
+    this.testLabels = this.datasetLabels.slice(
+        this.NUM_CLASSES * this.NUM_TRAIN_ELEMENTS,
+    );
+  }
+
+  nextTrainBatch(batchSize) {
+    return this.nextBatch(
+        batchSize,
+        [this.trainImages, this.trainLabels],
+        () => {
+          this.shuffledTrainIndex =
+          (this.shuffledTrainIndex + 1) % this.trainIndices.length;
+          return this.trainIndices[this.shuffledTrainIndex];
+        },
+    );
+  }
+
+  nextTestBatch(batchSize) {
+    return this.nextBatch(batchSize, [this.testImages, this.testLabels], () => {
+      this.shuffledTestIndex =
+        (this.shuffledTestIndex + 1) % this.testIndices.length;
+      return this.testIndices[this.shuffledTestIndex];
+    });
+  }
+
+  nextBatch(batchSize, data, index) {
+    const batchImagesArray = new Float32Array(
+        batchSize * this.IMAGE_SIZE * this.NUM_CHANNELS,
+    );
+    const batchLabelsArray = new Uint8Array(batchSize * this.NUM_CLASSES);
+
+    for (let i = 0; i < batchSize; i++) {
+      const idx = index();
+      const image = data[0].slice(
+          idx * this.IMAGE_SIZE * this.NUM_CHANNELS,
+          idx * this.IMAGE_SIZE * this.NUM_CHANNELS + this.IMAGE_SIZE * this.NUM_CHANNELS,
+      );
+      batchImagesArray.set(image, i * this.IMAGE_SIZE * this.NUM_CHANNELS);
+
+      const label = data[1].slice(
+          idx * this.NUM_CLASSES,
+          idx * this.NUM_CLASSES + this.NUM_CLASSES,
+      );
+      batchLabelsArray.set(label, i * this.NUM_CLASSES);
+    }
+
+    const xs = tf.tensor3d(batchImagesArray, [
+      batchSize,
+      this.IMAGE_SIZE,
+      this.NUM_CHANNELS,
+    ]);
+    const labels = tf.tensor2d(batchLabelsArray, [batchSize, this.NUM_CLASSES]).toFloat();
+
+    return {xs, labels};
+  }
+}
+
+function getDataset(req, res) {
+  // console.log(req.body.ar);
+  let userFolder = crypto.randomBytes(20).toString('hex');
+  if (!fs.existsSync('dataset')) {
+    fs.mkdirSync('dataset/');
+  }
+  fs.mkdirSync('dataset/' + userFolder);
+  fs.writeFile('dataset/' + userFolder + '/dataset.zip', req.body.file,
+      {encoding: 'base64'},
+      async function(err) {
+        let zip = new AdmZip('dataset/' + userFolder + '/dataset.zip');
+        await zip.extractAllTo('dataset/' + userFolder, true);
+        LABELS_PATH = 'dataset/' + userFolder + '/labels.bin';
+        IMAGES_SPRITE_PATH = 'dataset/' + userFolder + '/data.jpg';
+        fs.unlink('dataset/' + userFolder + '/dataset.zip', () => {});
+        res.json({status: 'DONE', userFolder: userFolder});
+      },
+  );
+}
+
+function deleteData(req, res) {
+  let dir = path.normalize(req.body.userFolder).replace(/^(\.\.(\/|\\|$))+/, '');
+  dir = path.join('./dataset/', dir);
+  fs.rmdir(dir, {recursive: true}, (err) => {
+    if (err) {
+      throw err;
+    }
+    console.log(`Temp folder deleted!`);
+  });
+  res.json({status: 'Temp folder deleted!'});
+}
+
+module.exports = {Data: Data, getDataset: getDataset, deleteData: deleteData};

--- a/handlers/datasetHandler.js
+++ b/handlers/datasetHandler.js
@@ -30,7 +30,7 @@ class Data {
     this.labels = null;
   }
   async load() {
-    var This = this;
+    let This = this;
     const imgRequest = new Promise((resolve) => {
       // console.log(this.IMAGES_SPRITE_PATH);
       inkjet.decode(fs.readFileSync(this.IMAGES_SPRITE_PATH), function(err, decoded) {
@@ -123,36 +123,42 @@ class Data {
   }
 }
 
-function getDataset(req, res) {
-  // console.log(req.body.ar);
-  let userFolder = crypto.randomBytes(20).toString('hex');
-  if (!fs.existsSync('dataset')) {
-    fs.mkdirSync('dataset/');
-  }
-  fs.mkdirSync('dataset/' + userFolder);
-  fs.writeFile('dataset/' + userFolder + '/dataset.zip', req.body.file,
-      {encoding: 'base64'},
-      async function(err) {
-        let zip = new AdmZip('dataset/' + userFolder + '/dataset.zip');
-        await zip.extractAllTo('dataset/' + userFolder, true);
-        LABELS_PATH = 'dataset/' + userFolder + '/labels.bin';
-        IMAGES_SPRITE_PATH = 'dataset/' + userFolder + '/data.jpg';
-        fs.unlink('dataset/' + userFolder + '/dataset.zip', () => {});
-        res.json({status: 'DONE', userFolder: userFolder});
-      },
-  );
+function getDataset() {
+  return function(req, res) {
+    let data = JSON.parse(req.body);
+    // console.log(req.body.ar);
+    let userFolder = crypto.randomBytes(20).toString('hex');
+    if (!fs.existsSync('dataset')) {
+      fs.mkdirSync('dataset/');
+    }
+    fs.mkdirSync('dataset/' + userFolder);
+    fs.writeFile('dataset/' + userFolder + '/dataset.zip', data.file,
+        {encoding: 'base64'},
+        async function(err) {
+          let zip = new AdmZip('dataset/' + userFolder + '/dataset.zip');
+          await zip.extractAllTo('dataset/' + userFolder, true);
+          LABELS_PATH = 'dataset/' + userFolder + '/labels.bin';
+          IMAGES_SPRITE_PATH = 'dataset/' + userFolder + '/data.jpg';
+          fs.unlink('dataset/' + userFolder + '/dataset.zip', () => {});
+          res.json({status: 'DONE', userFolder: userFolder});
+        },
+    );
+  };
 }
 
-function deleteData(req, res) {
-  let dir = path.normalize(req.body.userFolder).replace(/^(\.\.(\/|\\|$))+/, '');
-  dir = path.join('./dataset/', dir);
-  fs.rmdir(dir, {recursive: true}, (err) => {
-    if (err) {
-      throw err;
-    }
-    console.log(`Temp folder deleted!`);
-  });
-  res.json({status: 'Temp folder deleted!'});
+function deleteData() {
+  return function(req, res) {
+    let data = JSON.parse(req.body);
+    let dir = path.normalize(data.userFolder).replace(/^(\.\.(\/|\\|$))+/, '');
+    dir = path.join('./dataset/', dir);
+    fs.rmdir(dir, {recursive: true}, (err) => {
+      if (err) {
+        throw err;
+      }
+      console.log(`Temp folder deleted!`);
+    });
+    res.json({status: 'Temp folder deleted!'});
+  };
 }
 
 module.exports = {Data: Data, getDataset: getDataset, deleteData: deleteData};

--- a/handlers/modelTrainer.js
+++ b/handlers/modelTrainer.js
@@ -1,0 +1,167 @@
+const tf = require('@tensorflow/tfjs-node');
+
+// enable this and comment previous one for GPU (CUDA) training --
+// proper nvidia drivers needs to be installed on both base machine and container for gpu training
+// const tf = require('@tensorflow/tfjs-node-gpu');
+
+const Data = require('./datasetHandler.js');
+const AdmZip = require('adm-zip');
+
+let Layers = [];
+let Params = {};
+
+function getModel(Layers, Params, res) {
+  // console.log(Params)
+  let model;
+  try {
+    model = tf.sequential({
+      layers: Layers,
+    });
+
+    if (Params.advancedMode) {
+      model.compile({
+        optimizer: Params.optimizer,
+        loss: Params.modelCompileLoss,
+        metrics: Params.modelCompileMetrics,
+      });
+    } else {
+      model.compile({
+        optimizer: Params.optimizer,
+        loss: 'categoricalCrossentropy',
+        metrics: ['accuracy'],
+      });
+    }
+  } catch (error) {
+    res.status(400).json({message: error.message});
+    // res.send(error);
+  }
+
+  return model;
+}
+
+async function train(model, data, Params) {
+  let TRAIN_DATA_SIZE = Params.trainDataSize;
+  let TEST_DATA_SIZE = Params.testDataSize;
+  let WIDTH = Params.width;
+  let HEIGHT = Params.height;
+
+  const [trainXs, trainYs] = tf.tidy(() => {
+    const d = data.nextTrainBatch(TRAIN_DATA_SIZE);
+    return [
+      d.xs.reshape([TRAIN_DATA_SIZE, HEIGHT, WIDTH, data.NUM_CHANNELS]),
+      d.labels,
+    ];
+  });
+
+  const [testXs, testYs] = tf.tidy(() => {
+    const d = data.nextTestBatch(TEST_DATA_SIZE);
+    return [
+      d.xs.reshape([TEST_DATA_SIZE, HEIGHT, WIDTH, data.NUM_CHANNELS]),
+      d.labels,
+    ];
+  });
+
+  return model.fit(trainXs, trainYs, {
+    batchSize: Number(Params.batchSize),
+    validationData: [testXs, testYs],
+    epochs: Number(Params.epochs),
+    shuffle: Params.shuffle,
+    // callbacks: console.log(1),
+  });
+}
+
+async function run(Layers, Params, res, userFolder) {
+  try {
+    const data = new Data.Data();
+    data.IMAGE_SIZE = Params.height * Params.width;
+    data.NUM_CLASSES = Params.numClasses;
+    data.NUM_CHANNELS = Params.numChannels;
+    data.NUM_TEST_ELEMENTS = Params.testDataSize;
+    data.NUM_TRAIN_ELEMENTS = Params.trainDataSize;
+    // console.log(data);
+    try {
+      await data.load();
+      let model = getModel(Layers, Params, res);
+      model.summary();
+      await train(model, data, Params);
+      console.log('TRAINING DONE');
+      await model.save('file://./dataset/' + userFolder + '/');
+
+      let zip = new AdmZip();
+      zip.addLocalFile("./dataset/" + userFolder + '/model.json');
+      zip.addLocalFile("./dataset/" + userFolder + '/weights.bin');
+      zip.writeZip("./dataset/" + userFolder + '/' + Params.modelName +'.zip');
+
+      res.json({status: 'done'});
+    } catch (error) {
+      console.log(error);
+      res.status(400).json({message: error.message});
+      // res.send(error);
+    }
+  } catch (error) {
+    console.log(error);
+    res.status(400).json({message: error.message});
+    // res.send(error);
+  }
+}
+
+function makeLayers(layers, res, userFolder) {
+  delete layers[0].layer;
+  delete layers[layers.length - 1].layer;
+  Layers = [
+    tf.layers.conv2d(layers[0]),
+    tf.layers.dense(layers[layers.length - 1]),
+  ];
+  try {
+    for (let i = 1; i < layers.length - 1; i++) {
+      if (layers[i].layer == 'dense') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.dense(layers[i]));
+      } else if (layers[i].layer == 'conv2d') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.conv2d(layers[i]));
+      } else if (layers[i].layer == 'flatten') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.flatten(layers[i]));
+      } else if (layers[i].layer == 'batchNormalization') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.batchNormalization(layers[i]));
+      } else if (layers[i].layer == 'dropout') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.dropout(layers[i]));
+      } else if (layers[i].layer == 'maxpooling2d') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.maxPooling2d(layers[i]));
+      } else if (layers[i].layer == 'activation') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.activation(layers[i]));
+      } else if (layers[i].layer == 'conv2dTranspose') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.conv2dTranspose(layers[i]));
+      } else if (layers[i].layer == 'averagePooling2d') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.averagePooling2d(layers[i]));
+      } else if (layers[i].layer == 'globalAveragePooling2d') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.globalAveragePooling2d(layers[i]));
+      } else if (layers[i].layer == 'globalMaxPooling2d') {
+        delete layers[i].layer;
+        Layers.splice(Layers.length - 1, 0, tf.layers.globalMaxPooling2d(layers[i]));
+      }
+      // console.log(layers[i]);
+    }
+  } catch (error) {
+    console.log(error);
+    res.status(400).json({message: error.message});
+    return;
+  }
+
+  run(Layers, Params, res, userFolder);
+}
+
+function trainModel(req, res) {
+  Params = req.body.Params;
+  makeLayers(req.body.Layers, res, req.body.userFolder);
+}
+
+module.exports = {trainModel: trainModel};

--- a/handlers/modelTrainer.js
+++ b/handlers/modelTrainer.js
@@ -164,9 +164,24 @@ function makeLayers(layers, res, userFolder) {
   run(Layers, Params, res, userFolder);
 }
 
-function trainModel(req, res) {
-  Params = req.body.Params;
-  makeLayers(req.body.Layers, res, req.body.userFolder);
+function trainModel() {
+  return function(req, res) {
+    let data = JSON.parse(req.body);
+    Params = data.Params;
+    makeLayers(data.Layers, res, data.userFolder);
+  };
 }
 
-module.exports = {trainModel: trainModel};
+function sendTrainedModel() {
+  return function(req, res) {
+    let data = JSON.parse(req.body);
+    let downloadURL = '/workbench/download/' + data.userFolder;
+    let app = require('../caracal.js');
+    app.get(downloadURL, (req1, res1) =>
+      res1.download('./dataset/' + data.userFolder + '/' + data.Params.modelName + '.zip'),
+    );
+    res.json({url: downloadURL});
+  };
+}
+
+module.exports = {trainModel: trainModel, sendTrainedModel: sendTrainedModel};

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
   },
   "homepage": "https://github.com/camicroscope/caboodle#readme",
   "dependencies": {
+    "@tensorflow/tfjs-node": "^2.0.1",
+    "adm-zip": "^0.4.16",
     "atob": "^2.1.2",
     "express": "^4.17.1",
     "http-proxy-middleware": "^0.20.0",
+    "inkjet": "^2.1.2",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.6.0",
     "mongodb": "^3.3.5",

--- a/routes.json
+++ b/routes.json
@@ -346,5 +346,29 @@
     "handlers":[
       {"function":"wcido", "args": []}
     ]
+  },{
+    "route":"/workbench/uploadDataset",
+    "method":"post",
+    "handlers":[
+      {"function":"getDataset", "args": []}
+    ]
+  },{
+    "route":"/workbench/trainModel",
+    "method":"post",
+    "handlers":[
+      {"function":"trainModel", "args": []}
+    ]
+  },{
+    "route":"/workbench/deleteUserData",
+    "method":"post",
+    "handlers":[
+      {"function":"deleteDataset", "args": []}
+    ]
+  },{
+    "route":"/workbench/modelDownload",
+    "method":"post",
+    "handlers":[
+      {"function":"sendTrainedModel", "args": []}
+    ]
   }
 ]

--- a/routes.json
+++ b/routes.json
@@ -350,24 +350,28 @@
     "route":"/workbench/uploadDataset",
     "method":"post",
     "handlers":[
+      {"function":"permissionHandler", "args": [["Admin", "Editor"]]},
       {"function":"getDataset", "args": []}
     ]
   },{
     "route":"/workbench/trainModel",
     "method":"post",
     "handlers":[
+      {"function":"permissionHandler", "args": [["Admin", "Editor"]]},
       {"function":"trainModel", "args": []}
     ]
   },{
     "route":"/workbench/deleteUserData",
     "method":"post",
     "handlers":[
+      {"function":"permissionHandler", "args": [["Admin", "Editor"]]},
       {"function":"deleteDataset", "args": []}
     ]
   },{
     "route":"/workbench/modelDownload",
     "method":"post",
     "handlers":[
+      {"function":"permissionHandler", "args": [["Admin", "Editor"]]},
       {"function":"sendTrainedModel", "args": []}
     ]
   }


### PR DESCRIPTION
#### Works with [caMicroscope #426](https://github.com/camicroscope/caMicroscope/pull/426)

## Description
- The dataset zip is sent from the caMicroscope frontend and extracted into `/dataset/<randomUserFolder>/`
- The spritesheet and binary label files are parsed in `/handlers/datasetHandler.js`
- The model details i.e custom layers and parameters are handled at `/handlers/modelTrainer.js` along with model training process and some other utilities.
- Dockerfile has been updated with `node:14-stretch-slim` debian image since alpine has compatibility issues with TensorFlow C binaries. (Mentioned [here](https://github.com/camicroscope/Caracal/issues/44))
- I wasn't able to test GPU training since I don't have nvidia (CUDA enabled) gpu; though it should work out of the box.
If you are running on a Linux system that is CUDA compatible, try installing the GPU package using `  npm install @tensorflow/tfjs-node-gpu` and replacing the require statement with `require('@tensorflow/tfjs-node-gpu')` in `modelTrainer.js` **Note** that proper drivers needs to installed on both base machine and the conatiner in order to use it.


## How Has This Been Tested?
Tested on Firefox (79.0), Chrome (84.0), Brave (1.10.x) on Windows 10 and Linux-LTS (arch - deepin)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
