### PR TITLE
Generate Keys in Appropriate Directory

### DIFF
--- a/keys/make_key.sh
+++ b/keys/make_key.sh
@@ -1,1 +1,6 @@
-openssl req -subj '/CN=www.camicroscope.com/O=caMicroscope Local Instance Key./C=US' -x509 -nodes -newkey rsa:2048 -keyout key -out key.pub
+#!/usr/bin/env bash
+
+# to generate keys only in the /keys directory.
+PWD="$(dirname "$0")"
+
+openssl req -subj '/CN=www.camicroscope.com/O=caMicroscope Local Instance Key./C=US' -x509 -nodes -newkey rsa:2048 -keyout $PWD/key -out $PWD/key.pub


### PR DESCRIPTION
## Description
- add shebang to specify shell
- not kept as `/usr/bin/bash` because some systems can have `bash` at a different location
- add the directory to each file being generated

## Motivation and Context
- as described in #84 
- Fixes #84 

## How Has This Been Tested?
- by manually calling the said script from different locations

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14032427/112163313-eb4e2880-8c12-11eb-9274-7270bb4492b8.png)
![image](https://user-images.githubusercontent.com/14032427/112163479-13d62280-8c13-11eb-9367-eec3ee14d268.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
