### PR TITLE
Add service for single point of interaction with database

### DIFF
--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -1,185 +1,11 @@
-var mongo = require('mongodb');
-
-var MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost';
-var DISABLE_SEC = (process.env.DISABLE_SEC === 'true') || false;
-
-
-function mongoFind(database, collection, query) {
-  return new Promise(function(res, rej) {
-    try {
-      mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-        if (err) {
-          rej(err);
-        } else {
-          if (query['_id']) {
-            query['_id'] = new mongo.ObjectID(query['_id']);
-          }
-          var dbo = db.db(database);
-          dbo.collection(collection).find(query).toArray(function(err, result) {
-            if (err) {
-              rej(err);
-            }
-            // compatible wiht bindaas odd format
-            result.forEach((x) => {
-              x['_id'] = {
-                '$oid': x['_id'],
-              };
-            });
-            res(result);
-            db.close();
-          });
-        }
-      });
-    } catch (error) {
-      rej(error);
-    }
-  });
-}
-
-function mongoDistinct(database, collection, upon, query) {
-  return new Promise(function(res, rej) {
-    try {
-      mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-        if (err) {
-          rej(err);
-        } else {
-          var dbo = db.db(database);
-          dbo.collection(collection).distinct(upon, query, function(err, result) {
-            if (err) {
-              rej(err);
-            }
-            res(result);
-            db.close();
-          });
-        }
-      });
-    } catch (error) {
-      console.error(error);
-      rej(error);
-    }
-  });
-}
-
-function mongoAdd(database, collection, data) {
-  return new Promise(function(res, rej) {
-    // if data not array, make it one
-    if (!Array.isArray(data)) {
-      data = [data];
-    }
-    try {
-      mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-        if (err) {
-          rej(err);
-        } else {
-          var dbo = db.db(database);
-          dbo.collection(collection).insertMany(data, function(err, result) {
-            if (err) {
-              rej(err);
-            }
-            res(result);
-            db.close();
-          });
-        }
-      });
-    } catch (error) {
-      console.error(error);
-      rej(error);
-    }
-  });
-}
-
-function mongoDelete(database, collection, query) {
-  return new Promise(function(res, rej) {
-    mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-      try {
-        if (err) {
-          rej(err);
-        } else {
-          var dbo = db.db(database);
-          if (query['_id']) {
-            query['_id'] = new mongo.ObjectID(query['_id']);
-          }
-          dbo.collection(collection).deleteOne(query, function(err, result) {
-            if (err) {
-              rej(err);
-            }
-            delete result.connection;
-            res(result);
-            db.close();
-          });
-        }
-      } catch (error) {
-        console.error(error);
-        rej(error);
-      }
-    });
-  });
-}
-
-function mongoAggregate(database, collection, pipeline) {
-  return new Promise(function(res, rej) {
-    mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-      try {
-        if (err) {
-          rej(err);
-        } else {
-          var dbo = db.db(database);
-          dbo.collection(collection).aggregate(pipeline).toArray(function(err, result) {
-            if (err) {
-              rej(err);
-            }
-            // compatible wiht bindaas odd format
-            // result.forEach((x) => {
-            //   x['_id'] = {
-            //     '$oid': x['_id'],
-            //   };
-            // });
-            res(result);
-            db.close();
-          });
-        }
-      } catch (error) {
-        console.error(error);
-        rej(error);
-      }
-    });
-  });
-}
-
-function mongoUpdate(database, collection, query, newVals) {
-  return new Promise(function(res, rej) {
-    try {
-      mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-        if (err) {
-          rej(err);
-        } else {
-          var dbo = db.db(database);
-          if (query['_id']) {
-            query['_id'] = new mongo.ObjectID(query['_id']);
-          }
-          dbo.collection(collection).updateOne(query, newVals, function(err, result) {
-            if (err) {
-              console.log(err);
-              rej(err);
-            }
-            delete result.connection;
-            res(result);
-            db.close();
-          });
-        }
-      });
-    } catch (error) {
-      rej(error);
-    }
-  });
-}
+const DISABLE_SEC = (process.env.DISABLE_SEC === 'true') || false;
+const mongoDB = require("../service/database");
 
 var General = {};
 General.find = function(db, collection) {
   return function(req, res, next) {
     var query = req.query;
-    delete query.token;
-    mongoFind(db, collection, query).then((x) => {
+    mongoDB.add(db, collection, query).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -190,7 +16,7 @@ General.get = function(db, collection) {
   return function(req, res, next) {
     var query = req.query;
     delete query.token;
-    mongoFind(db, collection, {_id: req.query.id}).then((x) => {
+    mongoDB.find(db, collection, {_id: req.query.id}).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -201,7 +27,7 @@ General.distinct = function(db, collection, upon) {
   return function(req, res, next) {
     var query = req.query;
     delete query.token;
-    mongoDistinct(db, collection, upon, query).then((x) => {
+    mongoDB.distinct(db, collection, upon, query).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -211,7 +37,7 @@ General.distinct = function(db, collection, upon) {
 General.add = function(db, collection) {
   return function(req, res, next) {
     var data = JSON.parse(req.body);
-    mongoAdd(db, collection, data).then((x) => {
+    mongoDB.add(db, collection, data).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -225,7 +51,7 @@ General.update = function(db, collection) {
     var newVals = {
       $set: JSON.parse(req.body),
     };
-    mongoUpdate(db, collection, query, newVals).then((x) => {
+    mongoDB.update(db, collection, query, newVals).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -236,7 +62,7 @@ General.delete = function(db, collection) {
   return function(req, res, next) {
     var query = req.query;
     delete query.token;
-    mongoDelete(db, collection, query).then((x) => {
+    mongoDB.delete(db, collection, query).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -249,7 +75,7 @@ Presetlabels.add = function(req, res, next) {
   var query = req.query;
   delete query.token;
   var labels = JSON.parse(req.body);
-  mongoUpdate('camic', 'configuration', {'config_name': 'preset_label'}, {$push: {configuration: labels}}).then((x) => {
+  mongoDB.update('camic', 'configuration', {'config_name': 'preset_label'}, {$push: {configuration: labels}}).then((x) => {
     req.data = x;
     next();
   }).catch((e) => next(e));
@@ -287,7 +113,7 @@ Presetlabels.update = function(req, res, next) {
     newVals['$unset']['configuration.$.key'] = 1;
   }
 
-  mongoUpdate('camic', 'configuration',
+  mongoDB.update('camic', 'configuration',
       {
         'config_name': 'preset_label',
         'configuration.id': query.id,
@@ -301,7 +127,7 @@ Presetlabels.update = function(req, res, next) {
 Presetlabels.remove = function(req, res, next) {
   var query = req.query;
   delete query.token;
-  mongoUpdate('camic', 'configuration',
+  mongoDB.update('camic', 'configuration',
       {
         'config_name': 'preset_label',
       }, {$pull: {configuration: {id: query.id}}}).then((x) => {
@@ -337,7 +163,7 @@ Mark.spatial = function(req, res, next) {
       '$gt': parseFloat(query.footprint),
     };
   }
-  mongoFind('camic', 'mark', query).then((x) => {
+  mongoDB.find('camic', 'mark', query).then((x) => {
     req.data = x;
     next();
   }).catch((e) => next(e));
@@ -383,7 +209,7 @@ Mark.multi = function(req, res, next) {
     };
   }
 
-  mongoFind('camic', 'mark', query).then((x) => {
+  mongoDB.find('camic', 'mark', query).then((x) => {
     req.data = x;
     next();
   }).catch((e) => next(e));
@@ -415,12 +241,12 @@ Mark.findMarkTypes = function(req, res, next) {
         },
       },
     ];
-    mongoAggregate('camic', 'mark', pipeline).then((x) => {
+    mongoDB.aggregate('camic', 'mark', pipeline).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
   } else {
-    mongoDistinct('camic', 'mark', 'provenance.analysis', query).then((x) => {
+    mongoDB.distinct('camic', 'mark', 'provenance.analysis', query).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));
@@ -431,7 +257,7 @@ var Heatmap = {};
 Heatmap.types = function(req, res, next) {
   var query = req.query;
   delete query.token;
-  mongoFind('camic', 'heatmap', query, {
+  mongoDB.find('camic', 'heatmap', query, {
     'data': 0,
   }).then((x) => {
     x.forEach((x)=>delete x.data);
@@ -443,7 +269,7 @@ Heatmap.types = function(req, res, next) {
 var User = {};
 
 User.forLogin = function(email) {
-  return mongoFind('camic', 'user', {'email': email});
+  return mongoDB.find('camic', 'user', {'email': email});
 };
 
 User.wcido = function(req, res, next) {

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -5,7 +5,7 @@ var General = {};
 General.find = function(db, collection) {
   return function(req, res, next) {
     var query = req.query;
-    mongoDB.add(db, collection, query).then((x) => {
+    mongoDB.find(db, collection, query).then((x) => {
       req.data = x;
       next();
     }).catch((e) => next(e));

--- a/handlers/monitorHandlers.js
+++ b/handlers/monitorHandlers.js
@@ -1,29 +1,21 @@
-var mongo = require('mongodb');
+const {getConnection} = require("../service/database/connector");
 
-var MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost';
-// handle monitoring checks
-
-let monitor = {};
-
-monitor.check = function(type) {
-  if (type == "basic") {
-    return new Promise(function(res, rej) {
-      let checkMsg = {"status": "up", "checkType": "basic"};
-      res(checkMsg);
-    });
-  }
-  if (type == "mongo") {
-    return new Promise(function(res, rej) {
-      mongo.MongoClient.connect(MONGO_URI, function(err, db) {
-        if (err) {
-          rej(err);
-        } else {
-          res({"status": "up", "checkType": "mongo"});
-        }
-      });
-    });
-  }
+/**
+ * @param {string} type Monitor to check status of database connection
+ * @returns {Promise<{status:string, checkType:string}>} status of service
+ */
+const check = function(type) {
+  return new Promise((resolve, reject) => {
+    if (type === "basic") {
+      resolve({status: "up", checkType: "basic"});
+    } else if (type === "mongo") {
+      if (getConnection() === undefined) {
+        const error = new Error("Error connecting to database");
+        reject(error);
+      }
+      resolve({status: "up", checkType: "mongo"});
+    }
+  });
 };
 
-
-module.exports = monitor;
+module.exports = {check};

--- a/service/database/connector.js
+++ b/service/database/connector.js
@@ -15,9 +15,9 @@ class MongoDBConnector {
    */
   constructor() {
     /** connection specifics */
-    const connectionString = process.env.MONGO_URI || "127.0.0.1:27017";
+    const connectionString = process.env.MONGO_URI || "mongodb://127.0.0.1:27017";
     const databaseName = process.env.MONGO_DB || "camic";
-    const url = `mongodb://${connectionString}/${databaseName}`;
+    const url = `${connectionString}/${databaseName}`;
 
     /** connection configurations */
     const configs = {

--- a/service/database/connector.js
+++ b/service/database/connector.js
@@ -1,0 +1,61 @@
+const { MongoClient } = require("mongodb");
+
+/**
+ * @class MongoDBConnector
+ * @description This class is the single point configuration place for all
+ * operations that relate to the connection of the application with the
+ * database server.
+ *
+ * This class provides the connection objects that are used by database
+ * operations throughout the project.
+ */
+class MongoDBConnector {
+  /**
+   * @constructor to initialize connection to database server
+   */
+  constructor() {
+    /** connection specifics */
+    const connectionString = process.env.MONGO_URI || "127.0.0.1:27017";
+    const databaseName = process.env.MONGO_DB || "camic";
+    const url = `mongodb://${connectionString}/${databaseName}`;
+
+    /** connection configurations */
+    const configs = {
+      useUnifiedTopology: true,
+      useNewUrlParser: true,
+    };
+
+    this.name = databaseName;
+    this.client = new MongoClient(url, configs);
+  }
+
+  /**
+   * @async method to initialize the connection and store in application state
+   */
+  async init() {
+    await this.client.connect();
+    console.log(`[database:${this.name}] connected`);
+    this.db = {};
+    this.db[this.name] = this.client.db(this.name);
+  }
+}
+
+/** initialize an instance of mongoDB connection and kill process if connection fails */
+const connector = new MongoDBConnector();
+connector.init().catch((e) => {
+  console.error("error connecting to database");
+  process.exit(1);
+});
+
+/**
+ * to load connection instances in database operations
+ * @param {string} [databaseName=camic] Returns a connection to the said database
+ */
+const getConnection = (databaseName = "camic") => {
+  return connector.db[databaseName];
+};
+
+/** export the connector to be used by utility functions */
+module.exports = {
+  getConnection,
+};

--- a/service/database/index.js
+++ b/service/database/index.js
@@ -1,0 +1,169 @@
+const { getConnection } = require("./connector");
+const { transformIdToObjectId } = require("./util");
+
+/**
+ * @class Mongo
+ * @description Handles database operations, called via handler. This is like a generic that
+ * is used through the project to perform basic operations on the database.
+ */
+class Mongo {
+  /**
+   * Runs the MongoDB find() method to fetch documents.
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName Name of the collection to run operation on
+   * @param {document} query Specifies selection filter using query operators.
+   * To return all documents in a collection, omit this parameter or pass an empty document ({}).
+   * @param {boolean} [transform=false] check to transform the IDs to ObjectID in response
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.find/ Read MongoDB Reference}
+   */
+  static async find(database, collectionName, query, transform = true) {
+    try {
+      query = transformIdToObjectId(query);
+
+      const collection = getConnection(database).collection(collectionName);
+      const data = await collection.find(query).toArray();
+
+      /** allow caller method to toggle response transformation */
+      if (transform) {
+        data.forEach((x) => {
+          x["_id"] = {
+            $oid: x["_id"],
+          };
+        });
+      }
+
+      return data;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  /**
+   * Runs a distinct find operation based on given query
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName Name of the collection to run operations on
+   * @param {string} upon Field for which to return distinct values.
+   * @param {Document} query A query that specifies the documents from
+   * which to retrieve the distinct values.
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.distinct Read MongoDB Reference}
+   */
+  static async distinct(database, collectionName, upon, query) {
+    try {
+      const collection = getConnection(database).collection(collectionName);
+      const data = await collection.distinct(upon, query);
+      return data;
+    } catch (e) {
+      return [];
+    }
+  }
+
+  /**
+   * Runs insertion operation to create an array of new documents
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName Name of collection to run operation on
+   * @param {Array<document>} data Array of documents to insert into collection
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/  Read MongoDB Reference}
+   */
+  static async add(database, collectionName, data) {
+    /** if not an array, transform into array */
+    if (!Array.isArray(data)) {
+      data = [data];
+    }
+
+    try {
+      const collection = getConnection(database).collection(collectionName);
+      const data = await collection.insertMany(data);
+      return data;
+    } catch (e) {
+      return [];
+    }
+  }
+
+  /**
+   * Runs the delete operation on the first document that satisfies the filter conditions
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName Name of collection to run operation on
+   * @param {document} query Specifies deletion criteria using query operators
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.deleteOne/ Read MongoDB Reference}
+   */
+  static async delete(database, collectionName, filter) {
+    try {
+      filter = transformIdToObjectId(filter);
+
+      const collection = getConnection(database).collection(collectionName);
+      const result = await collection.deleteOne(filter);
+      delete result.connection;
+
+      return result;
+    } catch (error) {
+      return [];
+    }
+  }
+
+  /**
+   * Runs aggregate operation on given pipeline
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName Name of collection to run operation on
+   * @param {Array} pipeline Array containing all the aggregation framework commands for the execution.
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.aggregate/ Read MongoDB Reference}
+   */
+  static async aggregate(database, collectionName, pipeline) {
+    try {
+      const collection = getConnection(database).collection(collectionName);
+      const result = await collection.aggregate(pipeline).toArray();
+      return result;
+    } catch (error) {
+      return [];
+    }
+  }
+
+  /**
+   * Runs updateOne operation on documents that satisfy the filter condition.
+   *
+   * @async
+   * @param {string} database Name of the database
+   * @param {string} collectionName name of collection to run operation on
+   * @param {document} filter selection criteria for the update
+   * @param {document|pipeline} updates modifications to apply to filtered documents,
+   * can be a document or a aggregation pipeline
+   *
+   * {@link https://docs.mongodb.com/manual/reference/method/db.collection.updateOne/ Read MongoDB Reference}
+   */
+  static async update(database, collectionName, filter, updates) {
+    try {
+      filter = transformIdToObjectId(filter);
+
+      const collection = await getConnection(database).collection(collectionName);
+      const result = await collection.updateOne(filter, updates);
+      delete result.connection;
+      return result;
+    } catch (e) {
+      return e;
+    }
+  }
+}
+
+/** export to be import using the destructuring syntax */
+module.exports = {
+  add: Mongo.add,
+  find: Mongo.find,
+  update: Mongo.update,
+  delete: Mongo.delete,
+  aggregate: Mongo.aggregate,
+  distinct: Mongo.distinct,
+};

--- a/service/database/index.js
+++ b/service/database/index.js
@@ -38,7 +38,7 @@ class Mongo {
       return data;
     } catch (e) {
       console.error(e);
-      return e;
+      throw e;
     }
   }
 
@@ -61,7 +61,7 @@ class Mongo {
       return data;
     } catch (e) {
       console.error(e);
-      return [];
+      throw e;
     }
   }
 
@@ -87,7 +87,7 @@ class Mongo {
       return res;
     } catch (e) {
       console.error(e);
-      return [];
+      throw e;
     }
   }
 
@@ -112,7 +112,7 @@ class Mongo {
       return result;
     } catch (e) {
       console.error(e);
-      return [];
+      throw e;
     }
   }
 
@@ -133,7 +133,7 @@ class Mongo {
       return result;
     } catch (e) {
       console.error(e);
-      return [];
+      throw e;
     }
   }
 
@@ -153,13 +153,15 @@ class Mongo {
     try {
       filter = transformIdToObjectId(filter);
 
-      const collection = await getConnection(database).collection(collectionName);
+      const collection = await getConnection(database).collection(
+        collectionName
+      );
       const result = await collection.updateOne(filter, updates);
       delete result.connection;
       return result;
     } catch (e) {
       console.error(e);
-      return e;
+      throw e;
     }
   }
 }

--- a/service/database/index.js
+++ b/service/database/index.js
@@ -37,6 +37,7 @@ class Mongo {
 
       return data;
     } catch (e) {
+      console.error(e);
       return e;
     }
   }
@@ -59,6 +60,7 @@ class Mongo {
       const data = await collection.distinct(upon, query);
       return data;
     } catch (e) {
+      console.error(e);
       return [];
     }
   }
@@ -81,9 +83,10 @@ class Mongo {
 
     try {
       const collection = getConnection(database).collection(collectionName);
-      const data = await collection.insertMany(data);
-      return data;
+      const res = await collection.insertMany(data);
+      return res;
     } catch (e) {
+      console.error(e);
       return [];
     }
   }
@@ -107,7 +110,8 @@ class Mongo {
       delete result.connection;
 
       return result;
-    } catch (error) {
+    } catch (e) {
+      console.error(e);
       return [];
     }
   }
@@ -127,7 +131,8 @@ class Mongo {
       const collection = getConnection(database).collection(collectionName);
       const result = await collection.aggregate(pipeline).toArray();
       return result;
-    } catch (error) {
+    } catch (e) {
+      console.error(e);
       return [];
     }
   }
@@ -153,6 +158,7 @@ class Mongo {
       delete result.connection;
       return result;
     } catch (e) {
+      console.error(e);
       return e;
     }
   }

--- a/service/database/util.js
+++ b/service/database/util.js
@@ -11,11 +11,15 @@ const { ObjectID } = require("mongodb");
  * @link https://docs.mongodb.com/manual/reference/method/ObjectId/
  */
 const transformIdToObjectId = (query) => {
-  if (query["_id"]) {
-    query["_id"] = new ObjectID(query["_id"]);
+  const payload = { ...query };
+  try {
+    if (payload["_id"]) {
+      payload["_id"] = new ObjectID(payload["_id"]);
+    }
+    return payload;
+  } catch (e) {
+    return query;
   }
-
-  return query;
 };
 
 module.exports = { transformIdToObjectId };

--- a/service/database/util.js
+++ b/service/database/util.js
@@ -1,0 +1,21 @@
+const { ObjectID } = require("mongodb");
+
+/**
+ * Utility function to transform id from String format to ObjectID format
+ * See attached link for full reference:
+ *
+ * @description if the query contains a _id property, transforms it to an
+ * ObjectID format.
+ * @param {Object} query Incoming Query for database operation
+ *
+ * @link https://docs.mongodb.com/manual/reference/method/ObjectId/
+ */
+const transformIdToObjectId = (query) => {
+  if (query["_id"]) {
+    query["_id"] = new ObjectID(query["_id"]);
+  }
+
+  return query;
+};
+
+module.exports = { transformIdToObjectId };

--- a/test/unit/database.js
+++ b/test/unit/database.js
@@ -1,8 +1,8 @@
 const chai = require("chai");
-const { ObjectID } = require("mongodb");
+const {ObjectID} = require("mongodb");
 var should = chai.should();
 
-const { getConnection } = require("./../../service/database/connector");
+const {getConnection} = require("./../../service/database/connector");
 const MongoDB = require("./../../service/database/index");
 const Util = require("./../../service/database/util");
 
@@ -140,7 +140,7 @@ describe("service/database", () => {
 
     /** clear database after each unit */
     afterEach(async () => {
-      await getConnection().collection(DB.COLLECTION).deleteMany({ age: 20 });
+      await getConnection().collection(DB.COLLECTION).deleteMany({age: 20});
     });
 
     /** ensures that service always provides all database functionality */

--- a/test/unit/database.js
+++ b/test/unit/database.js
@@ -1,0 +1,216 @@
+const chai = require("chai");
+const { ObjectID } = require("mongodb");
+var should = chai.should();
+
+const { getConnection } = require("./../../service/database/connector");
+const MongoDB = require("./../../service/database/index");
+const Util = require("./../../service/database/util");
+
+/**
+ * The services are designed to operate as independent units and therefore by
+ * design, must not depend / interfere with the main codebase. This allows
+ * development and debugging without touching the application codebase.
+ */
+const DB = {
+  NAME: "camic",
+  COLLECTION: "users",
+};
+
+/**
+ * all tests for service/database
+ */
+describe("service/database", () => {
+  /** wait for connection before initiating tests */
+  before(async () => {
+    const connection = () =>
+      new Promise((resolve) => {
+        setTimeout(resolve(true), 1000 * 2);
+      });
+    await connection();
+  });
+
+  /** test suite for connector */
+  describe("connector", () => {
+    it("should be defined and callable", () => {
+      getConnection.should.not.be.undefined;
+      (typeof getConnection).should.equal("function");
+    });
+
+    it("should return a valid connection when no argument provided", () => {
+      const connection = getConnection();
+      connection.should.not.be.undefined;
+    });
+
+    it("should return a valid connection when database name provided", () => {
+      const connection = getConnection("camic");
+      connection.should.not.be.undefined;
+      connection.serverConfig.should.not.be.undefined;
+    });
+
+    it("should inject configuration objects", () => {
+      const connection = getConnection("camic");
+      connection.serverConfig.s.options.useUnifiedTopology.should.be.true;
+    });
+  });
+
+  /** test suite for utility functions */
+  describe("util", () => {
+    it("should be defined and callable", () => {
+      Util.should.not.be.undefined;
+      Util.transformIdToObjectId.should.not.be.undefined;
+      (typeof Util.transformIdToObjectId).should.equal("function");
+    });
+
+    it("should not alter argument if property _id not exist", () => {
+      const original = {
+        something: "awesome",
+        repo: "caracal",
+        valid: true,
+        version: 1,
+        string: "F",
+      };
+
+      const processed = Util.transformIdToObjectId(original);
+      processed.should.eql(processed);
+    });
+
+    it("should not alter original object passed into function", () => {
+      const original = {
+        foo: "bar",
+        number: 1,
+        _id: "507f1f77bcf86cd799439011",
+      };
+
+      const processed = Util.transformIdToObjectId(original);
+      (typeof original._id).should.be.equal("string");
+      (typeof processed._id).should.be.equal("object");
+    });
+
+    it("should alter datatype of property with valid _id", () => {
+      const original = {
+        foo: "bar",
+        number: 1,
+        _id: "507f1f77bcf86cd799439011",
+      };
+
+      (typeof original._id).should.be.equal("string");
+      const processed = Util.transformIdToObjectId(original);
+      (typeof processed._id).should.be.equal("object");
+    });
+
+    it("should not break if datatype of id not a valid ObjectID", () => {
+      const original = {
+        foo: "bar",
+        number: 1,
+        _id: "507f1_invalid_6cd799439011",
+      };
+
+      (typeof original._id).should.be.equal("string");
+      const processed = Util.transformIdToObjectId(original);
+      (typeof processed._id).should.be.equal("string");
+    });
+  });
+
+  /** test suite for core functionality */
+  describe("service", () => {
+    /** dummy payload for unit tests */
+    const USERS = [
+      {
+        _id: new ObjectID(),
+        name: "user 1",
+        age: 20,
+        config: {
+          foo: "bar",
+        },
+      },
+      {
+        _id: new ObjectID(),
+        name: "user 2",
+        age: 20,
+        config: {
+          foo: "bar",
+        },
+      },
+    ];
+
+    /** seed values before execution of each unit */
+    beforeEach(async () => {
+      await getConnection().collection(DB.COLLECTION).insertMany(USERS);
+    });
+
+    /** clear database after each unit */
+    afterEach(async () => {
+      await getConnection().collection(DB.COLLECTION).deleteMany({ age: 20 });
+    });
+
+    /** ensures that service always provides all database functionality */
+    it("should be defined and callable", () => {
+      MongoDB.should.not.be.undefined;
+      (typeof MongoDB).should.be.equal("object");
+      (typeof MongoDB.add).should.be.equal("function");
+      (typeof MongoDB.aggregate).should.be.equal("function");
+      (typeof MongoDB.delete).should.be.equal("function");
+      (typeof MongoDB.distinct).should.be.equal("function");
+      (typeof MongoDB.find).should.be.equal("function");
+      (typeof MongoDB.update).should.be.equal("function");
+    });
+
+    describe(".add", () => {
+      /** if it's callable, it means it's defined. */
+      it("should be callable", () => {
+        (typeof MongoDB.add).should.be.equal("function");
+      });
+
+      /** normal insert operations for single document */
+      it("should insert single document into collection", async () => {
+        const user = {
+          _id: new ObjectID(),
+          name: "testUser1",
+          age: 20,
+          config: {
+            foo: "bar",
+          },
+        };
+
+        const res = await MongoDB.add(DB.NAME, DB.COLLECTION, user);
+        res.insertedCount.should.be.equal(1);
+        res.result.n.should.be.equal(1);
+      });
+
+      /** should  */
+      it("should insert multiple document into collection", async () => {
+        const users = [
+          {
+            _id: new ObjectID(),
+            name: "testUser1",
+            age: 20,
+            config: {
+              foo: "bar",
+            },
+          },
+          {
+            _id: new ObjectID(),
+            name: "testUser2",
+            age: 20,
+            config: {
+              foo: "bar",
+            },
+          },
+        ];
+
+        const res = await MongoDB.add(DB.NAME, DB.COLLECTION, users);
+        res.insertedCount.should.be.equal(2);
+        res.result.n.should.be.equal(2);
+      });
+    });
+
+    /**
+     * @todo: unit tests for following methods
+     * .aggregate()
+     * .delete()
+     * .find()
+     * .update()
+     * .distinct()
+     */
+  });
+});


### PR DESCRIPTION
## Summary
There are three issues linked with the project, here's a summary of what this PR accomplishes.

- a central point of database interaction, provides a thin abstraction over mongdb driver. Takes care of points raised in #88.
- A tiny utility function to kill the process if database connections have failed after multiple tries. As discussed in #82 
- Rewrite of functions using the async-await syntax (replacing callbacks, fallbacks explained in #89 ) 


## Details
- util.js for commonly used utility functions that are consumed by database services, like data transformers.
- exhaustive JSDocs for each member function, with due references to MongoDB documentation.
- All functions which were previously scattered across the application (and also duplicated) combined into one class, eliminating redundancy in code.
- Single point to change the behavior of database connections
- single point connector that provides connection instances to other modules
- kills the process if the connection repeatedly fails.
- all the places which were initially interacting with the database have been refactored to use to database service along with the async-await syntax.
 
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->

## Motivation
- Fixes #82 
- Fixes #88 
- Fixes #89 

## Testing
- service tested by running along with the system, unit tests are in process of being written
- Screencast showing termination of process with NZEC as the connection was not successful.
[![asciicast](https://asciinema.org/a/402535.svg)](https://asciinema.org/a/402535)

## Questions
- Suggestions are welcomed.
- please suggest a suitable name for the PR.