### PR TITLE
wait for database to initialize before db calls

### DIFF
--- a/caracal.js
+++ b/caracal.js
@@ -24,6 +24,8 @@ const Model = require('./handlers/modelTrainer.js');
 const DataTransformationHandler = require('./handlers/dataTransformationHandler.js');
 // TODO validation of data
 
+const {connector} = require("./service/database/connector");
+
 var WORKERS = process.env.NUM_THREADS || 4;
 
 var PORT = process.env.PORT || 4010;
@@ -196,7 +198,14 @@ var startApp = function(app) {
 
 throng(WORKERS, startApp(app));
 
-const handler = new DataTransformationHandler(MONGO_URI, './json/configuration.json');
-handler.startHandler();
+/** initialize DataTransformationHandler only after database is ready */
+connector.init().then(() => {
+  const handler = new DataTransformationHandler(MONGO_URI, './json/configuration.json');
+  handler.startHandler();
+}).catch((e) => {
+  console.error("error connecting to database");
+  process.exit(1);
+});
 
 module.exports = app; // for tests
+

--- a/service/database/connector.js
+++ b/service/database/connector.js
@@ -15,7 +15,8 @@ class MongoDBConnector {
    */
   constructor() {
     /** connection specifics */
-    const connectionString = process.env.MONGO_URI || "mongodb://127.0.0.1:27017";
+    const connectionString =
+      process.env.MONGO_URI || "mongodb://127.0.0.1:27017";
     const databaseName = process.env.MONGO_DB || "camic";
     const url = `${connectionString}/${databaseName}`;
 
@@ -42,10 +43,6 @@ class MongoDBConnector {
 
 /** initialize an instance of mongoDB connection and kill process if connection fails */
 const connector = new MongoDBConnector();
-connector.init().catch((e) => {
-  console.error("error connecting to database");
-  process.exit(1);
-});
 
 /**
  * to load connection instances in database operations
@@ -58,4 +55,6 @@ const getConnection = (databaseName = "camic") => {
 /** export the connector to be used by utility functions */
 module.exports = {
   getConnection,
+  connector,
 };
+


### PR DESCRIPTION
## Summary
- wait for a database connection to initialize before operating on the database.

## Motivation
- as discussed in #96 

## Testing
- Manual build and run
- documented via https://asciinema.org/a/411059

## Note
- awaiting review to push the final linted and styled code.