### PR TITLE
Clone faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 RUN npm install
 ARG viewer
 ARG fork
-RUN git clone https://github.com/${fork:-camicroscope}/camicroscope.git --branch=${viewer:-master}
+RUN git clone https://github.com/${fork:-camicroscope}/camicroscope.git --branch=${viewer:-master} --depth 1
 EXPOSE 4010
 
 RUN chgrp -R 0 /src && \


### PR DESCRIPTION
This saves about 50 seconds on my computer by downloading only the latest commit, which we can use because we run no git commands, we only use the latest source code.