### PR TITLE
add "filesystem was updated" methods

### DIFF
--- a/caracal.js
+++ b/caracal.js
@@ -125,6 +125,8 @@ var HANDLERS = {
   "removePresetlabels": function() {
     return dataHandlers.Presetlabels.remove;
   },
+  "addedFileToFS": dataHandlers.FSChanged.added,
+  "removedFileFromFS": dataHandlers.FSChanged.removed,
 };
 
 // TODO! -- remove these by fully depreciating tfjs serverside

--- a/handlers/dataHandlers.js
+++ b/handlers/dataHandlers.js
@@ -457,7 +457,7 @@ FSChanged.added = function(db, collection, loader) {
           });
         }).catch((e) => {
           res.send({error: "mongo failure"});
-          print(e)
+          console.log(e);
         });
       });
     });

--- a/routes.json
+++ b/routes.json
@@ -491,5 +491,17 @@
       {"function":"permissionHandler", "args": [["Admin", "Editor"]]},
       {"function":"sendTrainedModel", "args": []}
     ]
+  },{
+    "route":"/fs/addedFile",
+    "method":"get",
+    "handlers":[
+      {"function":"addedFileToFS", "args": ["camic", "slide", "http://ca-load:4000"]}
+    ]
+  },{
+    "route":"/fs/deletedFile",
+    "method":"get",
+    "handlers":[
+      {"function":"removedFileFromFS", "args": ["camic", "slide", "http://ca-load:4000"]}
+    ]
   }
 ]

--- a/routes.json.example
+++ b/routes.json.example
@@ -1102,5 +1102,17 @@
         "args": []
       }
     ]
+  },{
+    "route":"/fs/addedFile",
+    "method":"get",
+    "handlers":[
+      {"function":"addedFileToFS", "args": ["camic", "slide", "http://ca-load:4000"]}
+    ]
+  },{
+    "route":"/fs/deletedFile",
+    "method":"get",
+    "handlers":[
+      {"function":"removedFileFromFS", "args": ["camic", "slide", "http://ca-load:4000"]}
+    ]
   }
 ]


### PR DESCRIPTION
Should be tested with: https://github.com/camicroscope/SlideLoader/pull/84

This Pull Request adds methods to notify Caracal of an updated filesystem, which it then uses to update the database. The two functions that I added don't require "permissionsHandler" because it verifies all the notifications and does not manipulate the filesystem. This is so that the DICOM server can request adding a new entry when it receives a new DICOM file

The logic is due to the current "1 entry = 1 file = 1 image" in MongoDB. Once the schema allows multiple files per entry, it can be simplified by much. I designed the minimal extension without changing the schema as: 

- 1 file in the flat /images directory is one image. Such a file doesn't have companion files and the image is represented only by that file only
- 1 subfolder of /images contains files (and maybe folders) that code for one image.

The "added" function is used when there's a new file. Pseudocode
- If not a relative path, error
- If there's no file at the path, error
- If it's in flat /images, check if already in database. If not, add it
- If it's in a subfolder of /images, check if database has any entries with filepath containing the subfolder. If so, return "already in db" otherwise, add the *file* as an entry (or any other file in the subfolder could have worked)

The "removed" function is used when a file was removed. Pseudocode:
- If not a relative path, error
- If there's a file at the path, error
- If it's in flat /images, delete all entries referring to that image.
- If it's in a subfolder of /images, check if there are any other files in the subfolder. If there is, replace all entries with filepaths toward inside anything in the subfolder with that file's path. If not, delete entries with filepath that subfolder.

I find that these functions are a good starting point before all db operations are isolated from the client. Currently, the frontend can call making a new entry for millions of inexistent files per minute, and it would be better to handle more at the backend.

Test strategy:

- I move a DICOM file to /images, "curl -v "http://localhost:4010/fs/addedFile?filepath=a.dcm"
- The entry should appear on camicroscope
- Move it to a subdir
- "curl -v "http://localhost:4010/fs/deletedFile?filepath=a.dcm"
- Entry should be gone
- "curl -v "http://localhost:4010/fs/addedFile?filepath=abc/a.dcm"
- new entry should appear
- duplicate it inside directory
- "curl -v "http://localhost:4010/fs/addedFile?filepath=abc/b.dcm"
- shouldn't be a new entry
- delete a.dcm
- "curl -v "http://localhost:4010/fs/deletedFile?filepath=abc/a.dcm"
- CaMicroscope should still be able to show the same image clicking on the entry
- delete b.dcm
- "curl -v "http://localhost:4010/fs/deletedFile?filepath=abc/b.dcm"
- the entry should be gone

---

In current schema, entries have "location" /images/abc/xyz.dcm, "filepath" abc/xyz.dcm and "filename" xyz.dcm and "name" user-entered-slidename. 

I suggest a new schema with the first three above are replaced with `subfolder: "abc", filepaths: ["xyz1.dcm", "xyz2.dcm"]` or `subfolder: ".", filepaths: ["a.tiff"]` There's already a problem that in SlideLoader /data/one gives location that might contain `\` on Windows but caMicroscope should use `/` everywhere and save in the database so.

Some filepaths would then contain '/' as I've seen a BioFormats image format that had "one file plus one folder"

The the frontend should call the iipsrv with `if (subfolder != '.') filepaths[0] else subfolder + '/' + filepaths[0]` so iipsrv should be able to handle relative paths, whereas it now uses absolute.

To modify this pull request's code, the pseudocodes would become:

The "added" function is used when there's a new file. Pseudocode
- If not a relative path, error
- If there's no file at the path, error
- If it's in flat /images, check if already in database with subfolder '.' and filepaths[0] = filename. If not, add it
- If it's in a subfolder of /images, check if database has any entries with subfolder == subfolderOfNewPath. If it finds any such entries: Check if the filename is in filepath array. If not, add it. If it could not find such entries: add an entry with subfolder and filepath

The "removed" function is used when a file was removed. Pseudocode:
- If not a relative path, error
- If there's a file at the path, error
- If it's in flat /images, delete all entries with subfolder == '.' and filepaths[0] = filename
- If it's in a subfolder of /images, for each entry found with subfolder = subfolderOfNewPath, check if the array contains the filename and remove it from there. If the array now has 0 filepaths, delete the entry